### PR TITLE
Performance improvements for the Julia code

### DIFF
--- a/play-optimally.jl
+++ b/play-optimally.jl
@@ -1,146 +1,131 @@
-words = readlines("solutions")
-non_solution_words = readlines("non-solution-guesses")
-allowed_guesses = append!(words, non_solution_words)
+using Printf: Format, format
 
 @enum ConstraintType has_no has_but_not_at has_at
 struct Constraint
-  type::ConstraintType
-  letter::Char
-  index::Int
+    type::ConstraintType
+    letter::UInt8
+    index::Int8
 end
 
-function isequal(c0::ConstraintType, c1::ConstraintType)::Bool
-  c0.type == c1.type && c0.letter == c1.letter && (c0.type == has_no || c0.index == c1.index)
+struct Choice
+    word::NTuple{5,UInt8}
+    avg_remaining::Float64
 end
 
-function hash(c::ConstraintType, h::UInt = 0)::UInt
-  hash(c.type, h) ⊻ hash(c.letter, h ⊻ 1) ⊻ hash(c.index, h ⊻ 2)
-end
-
-function constraints(guess::String, actual::String)::Array{Constraint}
-  c = Vector{Constraint}()
-  actual_letters = collect(actual)
-  for (i, g, a) in zip(1:5, guess, actual)
-    if g == a
-      push!(c, Constraint(has_at, g, i))
-    elseif g ∈ actual_letters
-      push!(c, Constraint(has_but_not_at, g, i))
-    else
-      push!(c, Constraint(has_no, g, i))
+function constraints(guess, actual)::Array{Constraint}
+    c = Vector{Constraint}(undef, length(guess))
+    @inbounds for (i, g, a) in zip(eachindex(c), guess, actual)
+        ctype = g == a ? has_at :
+                g in actual ? has_but_not_at :
+                has_no
+        c[i] = Constraint(ctype, g, trunc(Int8, i))
     end
-  end
-  c
+    return c
 end
 
 # Code: . = has_no, x = has_but_not_at, o = has_at
-function parse_constraints(template::String, guess::String)::Array{Constraint}
-  constraints = Vector{Constraint}()
-  for (i, c) in zip(1:5, template)
-    if c == 'x'
-      push!(constraints, Constraint(has_but_not_at, guess[i], i))
-    elseif c == 'o'
-      push!(constraints, Constraint(has_at, guess[i], i))
-    else
-      push!(constraints, Constraint(has_no, guess[i], i))
+function parse_constraints(template, guess)::Array{Constraint}
+    constraints = Vector{Constraint}(undef, length(template))
+    @inbounds for (i, c) in enumerate(template)
+        ctype = Char(c) == 'x' ? has_but_not_at :
+                Char(c) == 'o' ? has_at :
+                has_no
+        constraints[i] = Constraint(ctype, UInt8(guess[i]), trunc(Int8, i))
     end
-  end
-  constraints
+    return constraints
 end
 
-function match_constraint(word::String, constraint::Constraint)::Bool
-  letters = collect(word)
-  if constraint.type == has_no
-    constraint.letter ∉ letters
-  elseif constraint.type == has_but_not_at
-    (constraint.letter ∈ letters) && (word[constraint.index] != constraint.letter)
-  elseif constraint.type == has_at
-    word[constraint.index] == constraint.letter
-  end
-end
-
-function match_constraints(word::String, constraints::Array{Constraint})::Bool
-  for c in constraints
-    if !match_constraint(word, c)
-      return false
+function match_constraint(word, constraint)::Bool
+    if constraint.type == has_no
+        constraint.letter ∉ word
+    elseif constraint.type == has_but_not_at
+        (constraint.letter ∈ word) && (word[constraint.index] != constraint.letter)
+    elseif constraint.type == has_at
+        word[constraint.index] == constraint.letter
     end
-  end
-  return true
-  #all(map(c -> match_constraint(word, c), constraints))
 end
 
-memoize_remaining_for_constraint = Dict{Constraint,Array{String}}()
+function match_constraints(word, constraints::Array{Constraint})::Bool
+    return all(constraints) do c
+        match_constraint(word, c)
+    end
+end
+
+const memoize_remaining_for_constraint = Dict{Constraint,Vector{NTuple{5,UInt8}}}()
+
 function remaining_for_constraint(words::Array{String}, constraint::Constraint)::Array{String}
-  global memoize_remaining_for_constraint
-  if !haskey(memoize_remaining_for_constraint, constraint)
-    memoize_remaining_for_constraint[constraint] = Array(filter(w -> match_constraint(w, constraint), words))
-  end
-  return ∩(memoize_remaining_for_constraint[constraint], words)
+    if !haskey(memoize_remaining_for_constraint, constraint)
+        memoize_remaining_for_constraint[constraint] = [w for w in words if match_constraint(w, constraint)]
+    end
+    return ∩(memoize_remaining_for_constraint[constraint], words)
 end
 
 # Number of possible words left after performing a given guess against an actual
 # word of the day, and receiving the corresponding constraint information.
-function remaining(guess::String, actual::String, words::Array{String})::Float64
-  cs = constraints(guess, actual)
-  rem = 0
-  for w in words
-    rem += match_constraints(w, cs) ? 1 : 0
-  end
-  rem
-  #return foldl(function(a::Float64, w::String)::Float64
-  #  return a + (match_constraints(w, cs) ? 1 : 0)
-  #end, words, init = 0)
-  #length(reduce(∩, map(constraint -> remaining_for_constraint(words, constraint), cs)))
+function remaining(guess, actual, words::Vector)::Float64
+    cs = constraints(guess, actual)
+    rem = count(w -> match_constraints(w, cs), words)
+    return rem
 end
 
 # Average number of possible words left after performing a given guess,
 # and receiving the corresponding constraint information.
-function avg_remaining(guess::String, words::Array{String})::Float64
-  rem = 0
-  for w in words
-    rem += remaining(guess, w, words)
-  end
-  rem / length(words)
+function avg_remaining(guess, words::Vector)::Float64
+    rem = 0
+    for w in words
+        rem += remaining(guess, w, words)
+    end
+    rem / length(words)
 end
 
-struct Choice
-  word::String
-  avg_remaining::Float64
+function rank_guesses(guesses::Vector, words::Vector)
+    wt = length(guesses)
+    avg_time = 0
+    choices = Vector{Choice}(undef, wt)
+    for (wi, g) in zip(0:wt-1, guesses)
+        print("\x1b[1K\x1b[GRanking guesses... $(wi)/$(wt) words ($(ceil(Int, avg_time * (wt - wi) / 60)) min left)")
+        avg_time = (wi * avg_time + @elapsed choices[wi+1] = Choice(g, avg_remaining(g, words))) / (wi + 1)
+    end
+    print("\x1b[1K\x1b[G")
+    sort!(choices, by = c -> c.avg_remaining)
 end
 
-function rank_guesses(guesses::Array{String}, words::Array{String})::Array{Choice}
-  wt = length(guesses)
-  avg_time = 0
-  choices = Array{Choice}(undef, wt)
-  for (wi, g) in zip(0:wt-1, guesses)
-    print("\x1b[1K\x1b[GRanking guesses... ", wi, "/", wt, " words (", Int(ceil(avg_time*(wt-wi)/60)), " min left)")
-    avg_time = (wi*avg_time + @elapsed choices[wi+1] = Choice(g, avg_remaining(g, words))) / (wi+1)
-  end
-  #time = @elapsed choices = map(function(g::String)
-  #  print("\x1b[1K\x1b[GRanking guesses... ", wi, "/", wt, " words (", Int(ceil(time*(wt-wi)/60)), " min left)")
-  #  wi += 1
-  #  Choice(g, avg_remaining(g, words))
-  #end, guesses)
-  print("\x1b[1K\x1b[G")
-  sort!(choices, by = c -> c.avg_remaining)
+function read_words(io::IO)
+    buf = zeros(UInt8, 5)
+    words = NTuple{5,UInt8}[]
+    while !eof(io)
+        readbytes!(io, buf)
+        @inbounds word = ntuple(i -> buf[i], 5)
+        push!(words, word)
+        readline(io)
+    end
+    return words
 end
+
+read_words(fname::AbstractString) = open(read_words, fname)
 
 function main()
-  global words; global allowed_guesses
-  remaining_words = copy(words)  # List of words that currently fit all known constraints.
-  while length(remaining_words) > 1
-    best_guesses = rank_guesses(allowed_guesses, remaining_words)[1:10]
-    for (i, g) in zip(1:10, best_guesses)
-      println(i, ". ", g.word, " (keeps ", g.avg_remaining, " words on average)")
-    end
-    println("Insert your guess: ")
-    guess = readline(stdin)
-    println("Insert the results (o = letter at right spot, x = wrong spot, . = not in the word): ")
-    constraint_template = readline(stdin)
-    remaining_words = filter(w -> match_constraints(w, parse_constraints(constraint_template, guess)), remaining_words)
-  end
-  println("Solution: ", remaining_words[1], ".")
-end
-main()
+    solution_file = get(ARGS, 1, "solutions")
+    red_herring_file = get(ARGS, 2, "non-solution-guesses")
 
-# $ julia guess.jl
-# Ranking guesses... 1/12972 words (24950 min left)
+    words = read_words(solution_file)
+    non_solution_words = read_words(red_herring_file)
+    allowed_guesses = union(words, non_solution_words)
+
+    remaining_words = words  # List of words that currently fit all known constraints.
+    prop_fmt = Format("%d. %s (keeps %.4f words on average)\n")
+    while length(remaining_words) > 1
+        best_guesses = @view rank_guesses(allowed_guesses, remaining_words)[1:10]
+        for (i, g) in zip(1:10, best_guesses)
+            format(stdout, prop_fmt, i, String([g.word...]), g.avg_remaining)
+        end
+        println("Insert your guess: ")
+        guess = readline(stdin)
+        println("Insert the results (o = letter at right spot, x = wrong spot, . = not in the word): ")
+        constraint_template = readline(stdin)
+        remaining_words = filter(w -> match_constraints(w, parse_constraints(constraint_template, guess)), remaining_words)
+    end
+    println("Solution: ", String([remaining_words[]...]), ".")
+end
+
+main()


### PR DESCRIPTION
This PR summarizes some ideas from the [Julia Discourse discussion](https://discourse.julialang.org/t/rust-julia-comparison-post/75403) and my own code beautifications.

It is a fairly large refactoring, but with few key ideas.

I. Getting rid of all non-const globals
L108-109: Names for the files with possible words and "red herring" words are read from the command-line arguments (defaults are used if none provided)
L111-112: Arrays with possible and red herring words are created locally inside `main()`
L54: Memoization dictionary is made `const` (more on type signature later)

II. Fixing a bug
L113: Initially, it was `allowed_guesses = append!(words, non_solution_words)` which modified the `words` array. Now, it is a fresh array.
Fixing that vastly reduces the runtime, as the array `words` is much smaller than in the original version. It leads to ~30x speed improvement.

III. Using an optimized word storage type given our knowledge of the problem
L11: Given that all words are 5-letter and can only contain letters from the Latin alphabet, all characters are pure ASCII, so we can optimize the storage by using 5-tuples of their ASCII codes (`UInt8`).
L6: Same as above. Additionally, the index is in the range `1:5`, so that it can be stored as `Int8` (which gives some runtime improvement, albeit a minor one)

Given that tuples have fixed length, are immutable and are stored contiguously in arrays, compared to strings that are stored as references to heap-allocated data, that change gives another 10x speed improvement.

Another changes to support that type transition:
L54: Value type of memoization dictionary is `Vector{NTuple{5,UInt8}}`
various functions: removed argument type to save typing (can be added as `NTuple{5,UInt8}`)
L93, L105: Function `read_words()` is added to read words as 5-tuples instead of strings.
Defining a function with two methods, `foo(io::IO, args...)` and `foo(name::AbstractString, args...) = open(name) do io; foo(io, args...); end` is a common idiom in Julia for a function that either accepts directly an I/O stream or a filename which is opened and used as the respective stream.
L120, 128: Since a tuple of `UInt8`s is printed like `(0x01, 0x02, 0x03, 0x04, 0x05)`, `[word...]` is used to convert it first to a vector, and then `String(vec_of_UInt8)` to convert the vector to a string.

IV. Miscellaneous changes not affecting the performance
L65: `remaining` can be written as `count(w -> match_constraints(w, cs), words)` or `count(match_constraints(w, cs) for w in words)`.
L48: Loop can be refactored to `all(c -> match_constraint(word, c), constraints)` or `all(match_constraint(word, c) for c in constraints)`. The expression in parentheses is a generator, which produces values lazily, so that `all(...)` will short-circuit.
L73: Loop can be refactored into `rem = sum(remaining(guess, w, words) for w in words)`.
L15, 27: Avoiding `push!` using the known vector length.
L86: Using string interpolation for slightly improved readability. Refactor of `Int(ceil(x))` into `ceil(Int, x)`.
L1, 116, 120: Making use of C-like format strings (`Printf.Format`) to print floating point value to 4 digits in fractional part.